### PR TITLE
fix main.tf providers.tf variables.tf

### DIFF
--- a/terraform-hw/04/src/main.tf
+++ b/terraform-hw/04/src/main.tf
@@ -19,7 +19,7 @@
 #}
 
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=f96532a351d512ef1888e6c12a3d47c65fa10479"
   env_name       = "develop" 
   network_id     = module.vpc_dev.network_id
   subnet_zones   = ["ru-central1-a"]
@@ -41,7 +41,7 @@ module "marketing-vm" {
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=f96532a351d512ef1888e6c12a3d47c65fa10479"
   env_name       = "stage"
   network_id     = module.vpc_dev.network_id
   subnet_zones   = ["ru-central1-a"]

--- a/terraform-hw/04/src/providers.tf
+++ b/terraform-hw/04/src/providers.tf
@@ -1,9 +1,14 @@
 terraform {
   required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
+    }
     yandex = {
       source = "yandex-cloud/yandex"
-    }
-  }
+      version = ">= 0.85.0"
+      }
+}
   required_version = ">=1.8.4"
   backend "s3" {
     

--- a/terraform-hw/04/src/variables.tf
+++ b/terraform-hw/04/src/variables.tf
@@ -14,39 +14,40 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
 
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
+#variable "default_cidr" {
+#  type        = list(string)
+#  default     = ["10.0.1.0/24"]
+#  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
+#}
+
+#variable "vpc_name" {
+#  type        = string
+#  default     = "develop"
+#  description = "VPC network&subnet name"
+#}
 
 ###common vars
 
-variable "vms_ssh_root_key" {
-  type        = string
-  default     = "your_ssh_ed25519_key"
-  description = "ssh-keygen -t ed25519"
-}
+#variable "vms_ssh_root_key" {
+#  type        = string
+#  default     = "your_ssh_ed25519_key"
+#  description = "ssh-keygen -t ed25519"
+#}
 
 ###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
+#variable "vm_web_name" {
+#  type        = string
+#  default     = "netology-develop-platform-web"
+#  description = "example vm_web_ prefix"
+#}
 
 ###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
+#variable "vm_db_name" {
+#  type        = string
+#  default     = "netology-develop-platform-db"
+#  description = "example vm_db_ prefix"
+#}
 
 variable "ssh-authorized-keys" {
   description = "Path to public SSH key file"


### PR DESCRIPTION
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: marketing-vm
        File: /main.tf:21-41

                21 | module "marketing-vm" {
                22 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                23 |   env_name       = "develop"
                24 |   network_id     = module.vpc_dev.network_id
                25 |   subnet_zones   = ["ru-central1-a"]
                26 |   subnet_ids     = [module.vpc_dev.subnet_id]
                27 |   instance_name  = "marketing-vm"
                28 |   instance_count = 1
                29 |   image_family   = "ubuntu-2004-lts"
                30 |   public_ip      = true
                31 |
                32 |   labels = {
                33 |     project = "marketing"
                34 |      }
                35 |
                36 |   metadata = {
                37 |     user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
                38 |     serial-port-enable = 1
                39 |   }
                40 |
                41 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        FAILED for resource: marketing-vm
        File: /main.tf:21-41

                21 | module "marketing-vm" {
                22 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                23 |   env_name       = "develop"
                24 |   network_id     = module.vpc_dev.network_id
                25 |   subnet_zones   = ["ru-central1-a"]
                26 |   subnet_ids     = [module.vpc_dev.subnet_id]
                27 |   instance_name  = "marketing-vm"
                28 |   instance_count = 1
                29 |   image_family   = "ubuntu-2004-lts"
                30 |   public_ip      = true
                31 |
                32 |   labels = {
                33 |     project = "marketing"
                34 |      }
                35 |
                36 |   metadata = {
                37 |     user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
                38 |     serial-port-enable = 1
                39 |   }
                40 |
                41 | }

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: analytics-vm
        File: /main.tf:43-63

                43 | module "analytics-vm" {
                44 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                45 |   env_name       = "stage"
                46 |   network_id     = module.vpc_dev.network_id
                47 |   subnet_zones   = ["ru-central1-a"]
                48 |   subnet_ids     = [module.vpc_dev.subnet_id]
                49 |   instance_name  = "analytics-vm"
                50 |   instance_count = 1
                51 |   image_family   = "ubuntu-2004-lts"
                52 |   public_ip      = true
                53 |
                54 |   labels = {
                55 |     project = "analytics"
                56 |      }
                57 |
                58 |   metadata = {
                59 |     user-data          = data.template_file.cloudinit.rendered
                60 |     serial-port-enable = 1
                61 |   }
                62 |
                63 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        FAILED for resource: analytics-vm
        File: /main.tf:43-63

                43 | module "analytics-vm" {
                44 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
                45 |   env_name       = "stage"
                46 |   network_id     = module.vpc_dev.network_id
                47 |   subnet_zones   = ["ru-central1-a"]
                48 |   subnet_ids     = [module.vpc_dev.subnet_id]
                49 |   instance_name  = "analytics-vm"
                50 |   instance_count = 1
                51 |   image_family   = "ubuntu-2004-lts"
                52 |   public_ip      = true
                53 |
                54 |   labels = {
                55 |     project = "analytics"
                56 |      }
                57 |
                58 |   metadata = {
                59 |     user-data          = data.template_file.cloudinit.rendered
                60 |     serial-port-enable = 1
                61 |   }
                62 |
                63 | }
				

9 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 22:
  22:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 44:
  44:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 65:
  65: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 17:
  17: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 23:
  23: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vms_ssh_root_key" is declared but not used (terraform_unused_declarations)

  on variables.tf line 31:
  31: variable "vms_ssh_root_key" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_web_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 38:
  38: variable "vm_web_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_db_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 45:
  45: variable "vm_db_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.analytics-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hardware_generation       = (known after apply)
      + hostname                  = "stage-analytics-vm-0"
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "analytics"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHiZjyQiMYyn9ZJrggVSncksTiG+2NMFf2TVZmROmb6O ssilchin-deb

                package_update: true
                package_upgrade: false
                packages:
                 - vim
                 - nginx
            EOT
        }
      + name                      = "stage-analytics-vm-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8s6inq8cb33bdkk93k"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + metadata_options (known after apply)

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + placement_policy (known after apply)

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.marketing-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hardware_generation       = (known after apply)
      + hostname                  = "develop-marketing-vm-0"
      + id                        = (known after apply)
      + labels                    = {
          + "project" = "marketing"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHiZjyQiMYyn9ZJrggVSncksTiG+2NMFf2TVZmROmb6O ssilchin-deb

                package_update: true
                package_upgrade: false
                packages:
                 - vim
                 - nginx
            EOT
        }
      + name                      = "develop-marketing-vm-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8s6inq8cb33bdkk93k"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + metadata_options (known after apply)

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + placement_policy (known after apply)

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

  # module.vpc_dev.yandex_vpc_network.vpc will be created
  + resource "yandex_vpc_network" "vpc" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # module.vpc_dev.yandex_vpc_subnet.subnet will be created
  + resource "yandex_vpc_subnet" "subnet" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + dev_network_id = (known after apply)
  + dev_subnet_id  = (known after apply)